### PR TITLE
Item creation handled by Controller, fade on deletion

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,14 +6,11 @@ class ItemsController < ApplicationController
 
     if @item.save
       flash[:notice] = "Item was saved successfully."
+      redirect_to [@user]
     else
       flash.now[:alert] = "There was an error saving the item. Please try again."
     end
 
-    respond_to do |format|
-       format.html
-       format.js
-     end
   end
 
   def destroy

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,6 +1,6 @@
 <h4>Add an item</h4>
 
-<%= form_for [user, item], remote: true do |f| %>
+<%= form_for [user, item] do |f| %>
   <div class="form-group">
     <%= f.label :name, class: 'sr-only' %>
     <%= f.text_field :name, class: 'form-control', placeholder: "Enter a new item" %>

--- a/app/views/items/create.js.erb
+++ b/app/views/items/create.js.erb
@@ -1,8 +1,0 @@
-<% if @item.valid? %>
-  $('.js-items').append("<%= escape_javascript(render(@item)) %>");
-  $('.flash').prepend("<div class='alert alert-success'><button type='button' class='close' data-dismiss='alert'>&times;</button><%= flash.now[:notice] %></div>");
-  $('.new-item').html("<%= escape_javascript(render partial: 'items/form', locals: { user: @user, item: @new_item }) %>");
-<% else %>
-  $('.flash').prepend("<div class='alert alert-danger'><button type='button' class='close' data-dismiss='alert'>&times;</button><%= flash.now[:alert] %></div>");
-  $('.new-item').html("<%= escape_javascript(render partial: 'items/form', locals: { user: @user, item: @item }) %>");
-<% end %>

--- a/app/views/items/destroy.js.erb
+++ b/app/views/items/destroy.js.erb
@@ -1,5 +1,5 @@
 <% if @item.destroyed? %>
-  $('#item-<%= @item.id %>').hide();
+  $('#item-<%= @item.id %>').fadeOut(1300);
 <% else %>
   $('.flash').prepend("<div class='alert alert-danger'><button type='button' class='close' data-dismiss='alert'>&times;</button><%= flash.now[:alert] %></div>");
 <% end %>

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -2,32 +2,36 @@ require 'rails_helper'
 
 RSpec.describe ItemsController, type: :controller do
 
-  let(:my_user) { create(:user) }
-  let(:my_item) { create(:item, user: my_user) }
-  let(:my_item2) { create(:item, user: my_user) }
+  let(:user) { create(:user) }
+  let(:item) { create(:item, user: user) }
+  let(:item2) { create(:item, user: user) }
 
   describe "POST create" do
-
     it "increases the number of Item by 1" do
-      expect{ post :create, format: :js, user_id: my_user.id, item: {name: my_item.name} }.to change(Item,:count).by(1)
+      expect{ post :create, user_id: user.id, item: {name: item.name} }.to change(Item,:count).by(1)
     end
 
     it "increases the sum of user items by 1" do
-      count = my_user.items.count
-      post :create, format: :js, user_id: my_user.id, item_id: my_item2.id
-      expect(my_user.items.count).to eq(count + 1)
+      count = user.items.count
+      post :create, user_id: user.id, item_id: item2.id
+      expect(user.items.count).to eq(count + 1)
     end
   end
 
   describe "DELETE destroy" do
+
+    before do
+      sign_in user
+    end
+
     it "deletes the item" do
-      delete :destroy, format: :js, user_id: my_user.id, id: my_item.id
-      count = Item.where({id: my_item.id}).count
+      delete :destroy, format: :js, user_id: user.id, id: item.id
+      count = Item.where({id: item.id}).count
       expect(count).to eq(0)
     end
 
     it "returns http success" do
-      delete :destroy, format: :js, user_id: my_user.id, id: my_item.id
+      delete :destroy, format: :js, user_id: user.id, id: item.id
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
@emico7 I reviewed the code this morning and I think it would be simpler to do a redirect to user #show when you create an item. The requirements are looking for AJAX on deletion, not creation. I made the changes and it looks good (and it is fast). 

I also added a fade out feature to destroy. Try it out!

When I cloned down the master branch, there were two broken tests (both for ItemsController DELETE destroy). Can you please fix these in your next pull request? Thanks!

If everything looks good here, please merge and then pull down your local master branch. 
